### PR TITLE
add GET /api endpoint

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -2,7 +2,9 @@ const app = require('../app.js');
 const data = require('../db/data/test-data/index.js');
 const seed = require('../db/seeds/seed.js');
 const db = require('../db/connection.js');
+
 const request = require('supertest');
+const fs = require('fs/promises');
 
 beforeEach(() => {
     return seed(data);
@@ -13,13 +15,7 @@ afterAll(() => {
 });
 
 describe('GET /api/topics', () => {
-    it('should return a 200 http status code', () => {
-        return request(app)
-        .get('/api/topics')
-        .expect(200);
-    });
-
-    test('response data should be on a "topics" key', () => {
+    test('response data should be on a "topics" key with 200 http status', () => {
         return request(app)
         .get('/api/topics')
         .expect(200)
@@ -60,7 +56,14 @@ describe('GET /api/topics', () => {
         .get('/api/topics')
         .expect(200)
         .then(({ body }) => {
-            expect(body.topics).toEqual(seedTopics);
+            const responseTopics = body.topics.map(topic => {
+                const slug = topic.slug;
+                const description = topic.description;
+
+                return { slug, description };
+            });
+
+            expect(responseTopics).toEqual(seedTopics);
         });
     });
 
@@ -74,6 +77,154 @@ describe('GET /api/topics', () => {
             })
             .then(({ body }) => {
                 expect(body.msg).toBe('table not found');
+            });
+        });
+    });
+});
+
+describe('GET /api', () => {
+    test('response data should be on an "endpoints" key with 200 http status', () => {
+        return request(app)
+        .get('/api')
+        .expect(200)
+        .then(({ body }) => {
+            expect(body).toHaveProperty('endpoints');
+        });
+    });
+
+    test('each endpoint (apart from /api) should have correct object layout', () => {
+        const expectedLayout = {
+            description: expect.any(String),
+            allowedQueries: expect.any(Array),
+            exampleRequest: expect.any(Object),
+            exampleResponse: expect.any(Object)
+        };
+
+        return request(app)
+        .get('/api')
+        .expect(200)
+        .then(({ body }) => {
+            const endpoints = body.endpoints;
+
+            for (const endpoint in endpoints) {
+                if (endpoint !== "GET /api") {
+                    expect(endpoints[endpoint]).toMatchObject(expectedLayout);
+                }
+            }
+        });
+    });
+
+    test('example response from /api should match the format of the actual response provided by the endpoint', () => {
+
+        // this test should be dynamic for an evolving endpoints.json file
+        // so this test doesn't need to be updated when endpoints.json is updated
+
+        return request(app)
+        .get('/api')
+        .expect(200)
+        .then(({ body }) => {
+
+            // get list of endpoints from /api
+            
+            const endpoints = body.endpoints;
+            const supertestRequests = [];
+
+            for (const endpoint in endpoints) {
+                if (endpoint !== 'GET /api') {
+
+                    // extract METHOD and URL from each endpoint
+
+                    const method = endpoint.split(' ')[0];
+                    const url = endpoint
+                        .split(' ')[1]
+                        .replaceAll(/:[\w\d]+($|\/)/g, '1');     // (account for parametric endpoints - SQL serials, replace with 1)
+
+                    // extract the /api example response
+
+                    const exampleResponse = endpoints[endpoint].exampleResponse;
+                    const exampleRequest = endpoints[endpoint].exampleRequest;
+
+                    // also extract the key the response array is assigned to
+
+                    const wrapperKey = Object.keys(exampleResponse)[0];
+
+                    // make supertest requests to all endpoints (varying depening on METHOD)
+                    
+                    let pendingRequest;
+                    
+                    if (method === 'GET') {
+                        pendingRequest = request(app).get(url).send(exampleRequest).expect(200);
+                    }
+                    else if (method === 'POST') {
+                        pendingRequest = request(app).post(url).send(exampleRequest).expect(201);
+                    }
+                    else if (method === 'PATCH') {
+                        pendingRequest = request(app).patch(url).send(exampleRequest).expect(200);
+                    }
+                    else if (method === 'DELETE') {
+                        pendingRequest = request(app).delete(url).send(exampleRequest).expect(204);
+                    }
+                    
+                    // store the server response data as promise (alongside /api example response to compare to)
+                    // ...so all endpoint responses can be passed to next promise chain step together
+
+                    const dataElements = new Promise((resolve, reject) => {
+                        pendingRequest.then(({ body }) => {
+                            let elements = body[wrapperKey];
+                            if (!Array.isArray(elements)) elements = [elements];    // (account for requests not coming back as array, eg single item from database)
+
+                            let example = exampleResponse[wrapperKey];
+                            if (Array.isArray(example)) example = example[0];
+
+                            resolve({ example, elements });
+                        })
+                        .catch(err => reject(err));
+                    });
+
+                    supertestRequests.push(dataElements);
+                }
+            }
+
+            return Promise.all(supertestRequests);
+        })
+        .then(supertestResponses => {
+            
+            // iterate through server responses for each endpoint
+            
+            for (const response of supertestResponses) {
+                
+                // iterate through all elements in response array, compare them to example
+
+                for (const element of response.elements) {
+
+                    // iterate through all keys of endpoint response element
+                    // confirm the example does contain the required key with matching data type
+                    
+                    for(const key of Object.keys(element)) {
+                        expect(response.example).toHaveProperty(key);
+                        expect(typeof response.example[key]).toBe(typeof element[key]);
+                    }
+                }
+            }
+        });
+    });
+
+    describe('error handling', () => {
+        it('should return a http 500 error if endpoints.json file not available', () => {
+            const correctPath = `${__dirname}/../endpoints.json`;
+            const incorrectPath = `${__dirname}/../endpointsss.json`;
+
+            return fs.rename(correctPath, incorrectPath)
+            .then(() => {
+                return request(app)
+                .get('/api')
+                .expect(500)
+            })
+            .then(({ body }) => {
+                expect(body.msg).toBe('file not found');
+            })
+            .then(() => {
+                fs.rename(incorrectPath, correctPath);
             });
         });
     });

--- a/app.js
+++ b/app.js
@@ -1,14 +1,19 @@
 const express = require('express');
+const ApiController = require('./controllers/api.controller.js');
 const TopicsController = require('./controllers/topics.controller.js');
 const ErrorHandlers = require('./error-handlers/error-handlers.js');
 
 const app = express();
 
+// api
+app.get('/api', ApiController.getEndpointDetails);
+
 // topics
 app.get('/api/topics', TopicsController.getTopics);
 
 // errors
-app.use(ErrorHandlers.psqlErrorsHandler);
-app.use(ErrorHandlers.serverErrorsHandler);
+app.use(ErrorHandlers.fsErrorHandler);
+app.use(ErrorHandlers.psqlErrorHandler);
+app.use(ErrorHandlers.serverErrorHandler);
 
 module.exports = app;

--- a/controllers/api.controller.js
+++ b/controllers/api.controller.js
@@ -1,0 +1,13 @@
+const ApiModels = require('../models/api.models.js');
+
+class ApiContoller {
+    static getEndpointDetails(req, res, next) {
+        return ApiModels.getEndpointDetails()
+        .then(endpoints => {
+            res.status(200).send({ endpoints });
+        })
+        .catch(next);
+    }
+}
+
+module.exports = ApiContoller;

--- a/endpoints.json
+++ b/endpoints.json
@@ -1,29 +1,14 @@
 {
   "GET /api": {
-    "description": "serves up a json representation of all the available endpoints of the api"
+    "description": "responds with a json object containing details of each endpoint"
   },
   "GET /api/topics": {
-    "description": "serves an array of all topics",
-    "queries": [],
+    "description": "responds with an array of all topics",
     "exampleResponse": {
-      "topics": [{ "slug": "football", "description": "Footie!" }]
-    }
-  },
-  "GET /api/articles": {
-    "description": "serves an array of all topics",
-    "queries": ["author", "topic", "sort_by", "order"],
-    "exampleResponse": {
-      "articles": [
-        {
-          "title": "Seafood substitutions are increasing",
-          "topic": "cooking",
-          "author": "weegembump",
-          "body": "Text from the article..",
-          "created_at": "2018-05-30T15:59:13.341Z",
-          "votes": 0,
-          "comment_count": 6
-        }
-      ]
+      "topics": [{
+        "description": "The man, the Mitch, the legend",
+        "slug": "mitch"
+      }]
     }
   }
 }

--- a/error-handlers/error-handlers.js
+++ b/error-handlers/error-handlers.js
@@ -1,5 +1,12 @@
 class ErrorHandlers {
-    static psqlErrorsHandler(err, req, res, next) {
+    static fsErrorHandler(err, req, res, next) {
+        if (err.code === 'ENOENT') {
+            res.status(500).send({ msg: 'file not found' });
+        }
+        else next(err);
+    }
+
+    static psqlErrorHandler(err, req, res, next) {
         if (err.code === '42P01') {
             res.status(500).send({ msg: `table not found` });
         }
@@ -9,7 +16,7 @@ class ErrorHandlers {
         else next(err);
     }
 
-    static serverErrorsHandler(err, req, res, next) {
+    static serverErrorHandler(err, req, res, next) {
         res.status(500).send({ msg: 'unhandled internal server error' });
     }
 }

--- a/models/api.models.js
+++ b/models/api.models.js
@@ -1,0 +1,29 @@
+const fs = require('fs/promises');
+
+class ApiModels {
+    static getEndpointDetails() {
+        return fs.readFile(`${__dirname}/../endpoints.json`, 'utf-8')
+        .then(data => {
+            const endpoints = JSON.parse(data);
+
+            const requiredKeys = {
+                description: '',
+                allowedQueries: [],
+                exampleRequest: {},
+                exampleResponse: {}
+            };
+
+            for (const endpoint in endpoints) {
+                for (const key in requiredKeys) {
+                    if (!endpoints[endpoint].hasOwnProperty(key) && endpoint !== "GET /api") {
+                        endpoints[endpoint][key] = requiredKeys[key];
+                    }
+                }
+            }
+
+            return endpoints;
+        });
+    }
+}
+
+module.exports = ApiModels;


### PR DESCRIPTION
/api testing is quite long as it needs to be dynamic: ticket mentions making this test so it doesn't need updating as endpoints.json is updated

made some corrections from previous merge comments:
- removed http status checks as these are already in other tests
- altered /api/topics seed/response comparison to ignore the id number added by psql